### PR TITLE
fix: avoid plugin failure in case with parameters after *args

### DIFF
--- a/src/braket/flake8_plugins/braket_checkstyle_plugin.py
+++ b/src/braket/flake8_plugins/braket_checkstyle_plugin.py
@@ -259,7 +259,7 @@ class _Visitor(ast.NodeVisitor):
     ) -> None:
         expected_index = 0
         if context.previous_arg is None:
-            if node.args.args[0].arg in self.RESERVED_ARGS:
+            if node.args.args and node.args.args[0].arg in self.RESERVED_ARGS:
                 expected_index = 1
         elif arg_type == context.previous_arg[1]:
             expected_index = context.previous_arg[0] + 1

--- a/test/unit_tests/braket/flake8_plugins/example_files/no_error_functions.py
+++ b/test/unit_tests/braket/flake8_plugins/example_files/no_error_functions.py
@@ -151,6 +151,16 @@ def function_14(name: str, *, control: int = 0, target: int = 1) -> int:
     pass
 
 
+def function_15(*args, a0: int) -> int:
+    """This is a description.
+    Args:
+        a0 (int): This is a parameter
+    Returns:
+        int: value of the function
+    """
+    pass
+
+
 class MyClass:
     def __init__(self, a0:int):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In a case where a function has parameters listed after `*args` (and no parameters before), the plugin hits an unhandled `IndexError` exception and fails to complete.

Here is the exception that is hit (and is avoided with these changes):
```
    def _check_argument_order(
        self,
        arg_name: str,
        arg_index: int,
        arg_type: ArgType,
        context: DocContext,
        node: ast.FunctionDef,
    ) -> None:
        expected_index = 0
        if context.previous_arg is None:
>           if node.args.args[0].arg in self.RESERVED_ARGS:
E           IndexError: list index out of range

src\braket\flake8_plugins\braket_checkstyle_plugin.py:262: IndexError
```

*Testing done:*
Added a unit test to verify that the problem is fixed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
