### PR TITLE
fix: Allow `None` as default value for `Any` type hint

### DIFF
--- a/src/braket/flake8_plugins/braket_checkstyle_plugin.py
+++ b/src/braket/flake8_plugins/braket_checkstyle_plugin.py
@@ -307,7 +307,11 @@ class _Visitor(ast.NodeVisitor):
             and isinstance(default_value, ast.Constant)
             and default_value.value is None
         ):
-            if not documented_type.endswith("|None") and not documented_type.startswith("Optional"):
+            if (
+                documented_type != "Any"
+                and not documented_type.endswith("|None")
+                and not documented_type.startswith("Optional")
+            ):
                 self.add_problem(
                     node=node,
                     code="BCS023",

--- a/test/unit_tests/braket/flake8_plugins/example_files/missing_doc.py
+++ b/test/unit_tests/braket/flake8_plugins/example_files/missing_doc.py
@@ -1,15 +1,19 @@
+from typing import Any
+
+
 def my_function(a0: float, a1: float) -> float:
     val = a0 + a1 + 0.1
     return val
 
 
-def my_function_2(a0: int, a1: str | None = None, a2: str = None, a3: str | None = None) -> int:
+def my_function_2(a0: int, a1: str | None = None, a2: str = None, a3: str | None = None, a4: Any = None) -> int:  # noqa
     """This is a description.
     Args:
         a0 (int): This is a parameter
         a1 (str|None): This is an optional parameter
         a2 (str): This is an optional parameter missing optional type hint
         a3 (str|None): This is an optional parameter
+        a4 (Any): This is an optional parameter
     Returns:
         int: value of the function
     """

--- a/test/unit_tests/braket/flake8_plugins/test_braket_checkstyle_plugin.py
+++ b/test/unit_tests/braket/flake8_plugins/test_braket_checkstyle_plugin.py
@@ -41,8 +41,8 @@ def test_no_error_functions() -> None:
         (
             "missing_doc.py",
             {
-                "1:0 BCS003 - Function 'my_function' is missing documentation.",
-                "6:0 BCS023 - Argument 'a2' defaults to None but type hint doesn't end with '| None'.",  # noqa
+                "4:0 BCS003 - Function 'my_function' is missing documentation.",
+                "9:0 BCS023 - Argument 'a2' defaults to None but type hint doesn't end with '| None'.",  # noqa
             },
         ),
         (


### PR DESCRIPTION
*Issue #, if available:*
#21 

*Description of changes:*
Allow `None` as a default value for a parameter with type hint of `Any`.

*Testing done:*
Existing test case expanded to cover new functionality.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
